### PR TITLE
DM-47599: Fix build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,9 @@ jobs:
         run: make html
 
       - name: Upload documentation
-        env:
-          LTD_PASSWORD: ${{ secrets.LTD_PASSWORD }}
-          LTD_USERNAME: ${{ secrets.LTD_USERNAME }}
-        run: ltd upload --product citizen-science --gh --dir _build/html
+        uses: lsst-sqre/ltd-upload@v1
+        with:
+          project: "citizen-science"
+          dir: "_build/html"
+          username: ${{ secrets.ltd_username }}
+          password: ${{ secrets.ltd_password }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 documenteer[guide]
+sphinx==7.2.6


### PR DESCRIPTION
There is a bug where something in our pinned version of `pydata-sphinx-theme` is incompatible with `sphinx` >= `7.3.0`. What's weird is that it seems to be triggered only sometimes, though always in this pipeline for some reason.  In any case, pinning to `sphinx` `7.2.6` avoids it all the time.